### PR TITLE
[BUGFIX] Workaround loading order issue

### DIFF
--- a/Resources/Private/TypoScript/Packages/Swisscom.Neos.Monitoring.ts2
+++ b/Resources/Private/TypoScript/Packages/Swisscom.Neos.Monitoring.ts2
@@ -1,4 +1,6 @@
-prototype(TYPO3.Neos:Page) {
+# TODO: There's a problem with the loading order of packages. Therefore usage of prototype doesn't always work.
+#prototype(TYPO3.Neos:Page) {
+page {
 	monitoringString = ${Configuration.setting('Swisscom.Neos.Monitoring.monitoringString')} {
 		@process.wrapIfNotEmpty = ${value ? '<!-- Monitoring  -' + value + '- -->' : ''}
 		@position = 'before closingBodyTag'


### PR DESCRIPTION
There's a problem with the loading order of packages. Therefore usage of
prototype doesn't always work. By using `page` instead of
`prototype(TYPO3.Neos:Page)` it worked in my case.